### PR TITLE
fix(marketplace): use github source object to fix schema validation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,11 @@
   "plugins": [
     {
       "name": "myusage",
-      "source": ".",
+      "source": {
+        "type": "github",
+        "repo": "bdangit/myusage-skill",
+        "ref": "main"
+      },
       "description": "Generate a personal AI usage insights report from local Claude Code and Copilot chat history.",
       "version": "1.0.0",
       "author": {


### PR DESCRIPTION
## Summary

- Fixes `plugins.0.source: Invalid input` error when running `/plugin marketplace add bdangit/myusage-skill`
- `"source": "."` is not a valid schema value — replaced with an explicit GitHub source object: `{ "type": "github", "repo": "bdangit/myusage-skill", "ref": "main" }`

## Test plan

- [ ] Run `/plugin marketplace add bdangit/myusage-skill` — should succeed without schema error
- [ ] Run `/plugin install myusage@myusage-skill` — should install the skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)